### PR TITLE
Add Ankra blog posts to the writing section

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -483,6 +483,27 @@
                     did and experienced, and now I enjoy doing it. Full disclosure though, I
                     haven't written in a year. Gotta lock in.
                 </p>
+                <p class="section-note">
+                    I do write at work though. These are for the
+                    <a href="https://ankra.ai/blog" target="_blank" rel="noopener noreferrer">Ankra blog</a>,
+                    hands-on guides for running real workloads on Kubernetes.
+                </p>
+                <ul class="talk-list">
+                    <li>
+                        <div>
+                            <strong><a href="https://ankra.ai/blog/postgres-on-kubernetes" target="_blank" rel="noopener noreferrer">Postgres on Kubernetes Is No Longer a Dare</a></strong>
+                            <span class="talk-role">The &ldquo;never run a database on Kubernetes&rdquo; rule predates CSI and operators. What production Postgres takes in 2026, and when managed still wins.</span>
+                        </div>
+                        <span class="talk-date">Aug 2026</span>
+                    </li>
+                    <li>
+                        <div>
+                            <strong><a href="https://ankra.ai/blog/minimalist-guide" target="_blank" rel="noopener noreferrer">The Minimalist&rsquo;s Guide to Homelab Setup</a></strong>
+                            <span class="talk-role">Deploying the essential homelab applications with Ankra in a few clicks.</span>
+                        </div>
+                        <span class="talk-date">Aug 2025</span>
+                    </li>
+                </ul>
             </section>
 
             <section class="section" id="contact" aria-labelledby="contact-heading">


### PR DESCRIPTION
Adds the two posts written for the Ankra blog to the **Writing** section of the portfolio.

| Post | Date |
|---|---|
| [Postgres on Kubernetes Is No Longer a Dare](https://ankra.ai/blog/postgres-on-kubernetes) | Aug 2026 |
| [The Minimalist's Guide to Homelab Setup](https://ankra.ai/blog/minimalist-guide) | Aug 2025 |

Both confirmed from the author page at `ankra.ai/blog/author/shiva-swaroop`, which lists exactly these two.

**Approach:** reuses the existing `talk-list` / `talk-role` / `talk-date` classes from the Speaking section, so the styling matches and `styles.css` is untouched. Titles link out with `target="_blank" rel="noopener noreferrer"`, matching the convention used elsewhere on the page.

**Left alone deliberately:** the existing "I haven't written in a year" line refers to your own blog, *Shiv Writes About Stuff*, which is a different thing from the Ankra posts — so it stays true and I didn't touch it.

**Worth considering separately:** the `#writing` section still isn't in the top nav (`about, now, work, projects, oss, practice, talks, photos, contact`). Now that it has content, it may deserve a link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NLLTZyFPqdATABQNYTdiYc