### PR TITLE
List the Ankra posts in the agent surfaces too

### DIFF
--- a/public/agent.md
+++ b/public/agent.md
@@ -114,6 +114,12 @@ published as official content; the rest are public by link:
 Blog: *Shiv Writes About Stuff*, https://shivu.io/blog (hosted on Notion).
 What he learns, builds, and breaks; not all of it technical.
 
+For the Ankra blog (https://ankra.ai/blog), hands-on guides for running real
+workloads on Kubernetes:
+
+- Postgres on Kubernetes Is No Longer a Dare (Aug 2026) — https://ankra.ai/blog/postgres-on-kubernetes
+- The Minimalist's Guide to Homelab Setup (Aug 2025) — https://ankra.ai/blog/minimalist-guide
+
 ## Contact
 
 - Email: shivaswaroop40@gmail.com

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -21,6 +21,7 @@ of HTML.
 
 - [GitHub](https://github.com/shivaswaroop40): containerImages (supply-chain security pipeline), carnatic.xyz, and more
 - [iximiuz Labs author profile](https://labs.iximiuz.com/a/shiva-swaroop): five hands-on Kubernetes challenges he has authored (CKA practice, pod-certificate mTLS; full list at https://shivu.io/#practice)
+- [Ankra blog posts](https://ankra.ai/blog/author/shiva-swaroop): two hands-on Kubernetes guides written for Ankra (Postgres on Kubernetes; homelab setup)
 - [LinkedIn](https://linkedin.com/in/shivaswaroop-nittoor-krishnamurthy-67551a14b)
 - [X](https://x.com/podsandkapi)
 - [Cloud Native Stockholm](https://community.cncf.io/cloud-native-stockholm/): CNCF community group he co-organizes

--- a/public/resume.json
+++ b/public/resume.json
@@ -106,7 +106,22 @@
       "url": "https://nebius.com/certification"
     }
   ],
-  "publications": [],
+  "publications": [
+    {
+      "name": "Postgres on Kubernetes Is No Longer a Dare",
+      "publisher": "Ankra",
+      "releaseDate": "2026-08-03",
+      "url": "https://ankra.ai/blog/postgres-on-kubernetes",
+      "summary": "The \"never run a database on Kubernetes\" rule predates CSI and operators. What production Postgres takes in 2026, and when managed still wins."
+    },
+    {
+      "name": "The Minimalist's Guide to Homelab Setup",
+      "publisher": "Ankra",
+      "releaseDate": "2025-08-11",
+      "url": "https://ankra.ai/blog/minimalist-guide",
+      "summary": "Deploying the essential homelab applications with Ankra in a few clicks."
+    }
+  ],
   "skills": [
     { "name": "Kubernetes", "keywords": ["EKS", "Flux", "ArgoCD", "Kyverno", "Cilium", "eBPF", "NetworkPolicy"] },
     { "name": "Infrastructure as Code", "keywords": ["Terraform", "Ansible", "GitOps"] },


### PR DESCRIPTION
Follow-up to #4, which only updated `public/index.html`. The site serves the same content three other ways, and they were all still missing the Ankra posts.

- **`public/agent.md`** — added them under `## Writing`, matching the list style used for talks.
- **`public/llms.txt`** — added an entry under `Elsewhere`, pointing at the author page, matching the iximiuz entry pattern.
- **`public/resume.json`** — the `publications` array was `[]`. Now carries both posts in JSON Resume shape (`name`, `publisher`, `releaseDate`, `url`, `summary`).

Edited as text rather than re-serialised, so the diff is 17 lines rather than a whole-file reformat. `resume.json` parses.

Note: the Cloudflare deploy workflow has failed on every run since at least 1 Sept, well before these changes — deploying locally is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NLLTZyFPqdATABQNYTdiYc