### PR TITLE
Fix the Finland meetup date (Nov 2025)

### DIFF
--- a/public/agent.md
+++ b/public/agent.md
@@ -103,8 +103,8 @@ published as official content; the rest are public by link:
 - Co-organizer, Cloud Native Stockholm (CNCF community group)
 - Community organizer, [Agentic AI Foundation](https://aaif.io) (formerly the
   MLOps Community, now the Linux Foundation's AAIF user community)
-- Finland Kubernetes & CNCF Meetup — speaker (Nov 2026)
 - Cloud Native Stockholm — "Is this policy safe to turn on?" (Sep 2026), slides at https://shivu.io/talks/safe-to-turn-on/
+- Finland Kubernetes & CNCF Meetup — speaker (Nov 2025)
 - Platform Engineering Stockholm — "From Swarm to Cattle: An Orchestration Story" (Oct 2025)
 - Stockholm Cloud Native Community Group — "Is Your Software Supply-Chain Secure?"
   + panelist on cloud-native AI (Feb 2025), slides (PDF) at

--- a/public/index.html
+++ b/public/index.html
@@ -367,17 +367,17 @@
                 <ul class="talk-list">
                     <li>
                         <div>
-                            <strong>Finland Kubernetes &amp; CNCF Meetup</strong>
-                            <span class="talk-role">Speaker</span>
-                        </div>
-                        <span class="talk-date">Nov 2026</span>
-                    </li>
-                    <li>
-                        <div>
                             <strong>Cloud Native Stockholm</strong>
                             <span class="talk-role">Speaker: “Is this policy safe to turn on?” · <a href="/talks/safe-to-turn-on/">slides</a></span>
                         </div>
                         <span class="talk-date">Sep 2026</span>
+                    </li>
+                    <li>
+                        <div>
+                            <strong>Finland Kubernetes &amp; CNCF Meetup</strong>
+                            <span class="talk-role">Speaker</span>
+                        </div>
+                        <span class="talk-date">Nov 2025</span>
                     </li>
                     <li>
                         <div>


### PR DESCRIPTION
The Finland Kubernetes & CNCF Meetup talk was in November 2025, not 2026. Corrects the date and moves the entry into chronological order on the front page and in agent.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GiEDcuhCwEAN5zrxmak56B