### PR TITLE
Deck: drop the handles line from the whoami slide

### DIFF
--- a/public/talks/safe-to-turn-on/index.html
+++ b/public/talks/safe-to-turn-on/index.html
@@ -147,7 +147,6 @@
           <li>MSc Communication Systems, KTH · thesis at Ankra</li>
           <li>Co-organizer, Cloud Native Stockholm</li>
           <li>CKA · Carnatic music · filter coffee</li>
-          <li class="mono">shivu.io · @podsandkapi</li>
         </ul>
       </div>
       <img class="me" alt="Shiva Swaroop N K">


### PR DESCRIPTION
Removes the shivu.io / @podsandkapi line from slide 2 of the hosted deck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GiEDcuhCwEAN5zrxmak56B